### PR TITLE
Account for `box-sizing: border-box`

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,16 @@ export default function getCaretCoordinates(element, position, options) {
       } else {
         style.lineHeight = computed.height
       }
+    } else if (!isInput && prop === 'width' && computed.boxSizing === 'border-box') {
+      // With box-sizing: border-box we need to offset the size slightly inwards.  This small difference can compound
+      // greatly in long textareas with lots of wrapping, leading to very innacurate results if not accounted for.
+      // Firefox will return computed styles in floats, like `0.9px`, while chromium might return `1px` for the same element.
+      // Either way we use `parseFloat` to turn `0.9px` into `0.9` and `1px` into `1`
+      let totalBorderWidth = parseFloat(computed.borderLeftWidth) + parseFloat(computed.borderRightWidth)
+      // When a vertical scrollbar is present it shrinks the content. We need to account for this by using clientWidth
+      // instead of width in everything but Firefox. When we do that we also have to account for the border width.
+      let width = isFirefox ? parseFloat(computed[prop]) - totalBorderWidth : element.clientWidth + totalBorderWidth
+      style[prop] = `${width}px`
     } else {
       style[prop] = computed[prop]
     }

--- a/test/index.css
+++ b/test/index.css
@@ -24,3 +24,7 @@ input[type="text"] {
 .col {
   margin-right: 2em;
 }
+
+.border-box {
+  box-sizing: border-box;
+}

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <title>input and textarea caret-position testing ground</title>
     <link rel="stylesheet" type="text/css" href="index.css">
-    <script src="../index.js"></script>  <!-- this will trigger an `Uncaught ReferenceError: module is not defined`, which can be safely ignored -->
   </head>
   <body>
     <h1>Textarea/input caret position</h1>
@@ -75,8 +74,46 @@
       </div>
     </div>
 
-    <script>
-      ['input[type="text"]', 'textarea'].forEach(function (selector) {
+    <h2><code>&lt;textarea> with box-sizing: border-box</code></h2>
+    <div class="side-by-side">
+      <textarea rows="25" cols="40" class="col border-box">
+      1. Place cursor before "T" below
+      Then press arrow dow'n
+      2.PressHomeOnThisLineThenLeftArrow
+      Firefox fails, #sorrow
+      And now you're in my way
+		And	tabs	are	handled	just	fine
+      Except in IE9.
+
+      3. I'd trade my soul for averylongwordthatgetswrappedaway,
+      Press End on line 3
+      All browsers are faili'n,
+      But now you're in my way
+
+      Your stare was holdin',
+      Ripped jeans, skin was showin'
+      Hot night, wind was blowin'
+      Where do you think you're going, baby?
+
+      Hey, I just met you,
+      And this is crazy,
+      But here's my number,
+      So call me, maybe!
+      </textarea>
+      <div class="col">
+        <h3><code>&lt;textarea></code> manual tests</h3>
+        <ol>
+          <li>Place the cursor before the "T" in "Then" then press arrow down. Fails in Chrome 58, Firefox 53. (<a href="https://github.com/component/textarea-caret-position/issues/9#issuecomment-303601894">#9)</a></li>
+          <li>Place the cursor before "2." and press left arrow. Fails in Firefox 53, works in Chrome. (<a href="https://github.com/component/textarea-caret-position/issues/24#issuecomment-201913059">#24</a>)</li>
+          <li>Place the cursor at the beginning of line "3." then press End. Fails in Chrome 58, Firefox 53. (#9)</li>
+          <li>Click at the end of lines with spaces (e.g. "3." or the line before "2."). Fails in Chrome 58, Firefox 53. (#9)</li>
+        </ol>
+      </div>
+    </div>
+
+    <script type="module">
+      import getCaretCoordinates from "../index.js"
+      ['input[type="text"]', 'textarea', 'textarea.border-box'].forEach(function (selector) {
         var element = document.querySelector(selector);
         var fontSize = getComputedStyle(element).getPropertyValue('font-size');
 


### PR DESCRIPTION
## Background

This is some of the upshot from the investigation in https://github.com/github/github/pull/200660
After some initial investigation I realized that I hadn't properly evaluated `textarea-caret`'s behavior when a scrollbar was present.  We use `box-sizing: border-box` everywhere, but the test page doesn't. I was stumped for a little while until I read through the properties carefully.



## What this PR does
1. Adds a test for a `<textarea>` with `box-sizing: border-box`.  Along the way I converted the test page to properly use the new ES module -- I think it's broken in the base branch.
Here's an example of the bad behavior in chrome. Note the cursor is off by a few lines, and you can see visible differences in the line wrapping.

https://user-images.githubusercontent.com/2043348/144933395-d75a1b2b-d834-422c-aab1-99f64bf3870e.mp4

Firefox is much better but still has small differences in width that add up (Firefox also scrolls for you when you click in the demo, forgive the jerkiness). This is especially apparent in the last few seconds of the video. 

https://user-images.githubusercontent.com/2043348/144933499-d0757377-4440-469d-a8a2-ac617858614a.mp4

2. Adds special case code for `box-sizing: border-box`.  Webkit/Chromium and Firefox needed separate fixes.  I've evaluated these through quite a bit of trial and error, and I think this makes the results pixel-perfect on all three browsers.
Here's chrome after the fix. Note the cursor and wrapping line up perfectly now.

https://user-images.githubusercontent.com/2043348/144933648-ac57238d-02c7-49c5-82f1-9a69c99c1c57.mp4

Firefox is also fixed from what I can tell, both testing here and in [the other PR](https://github.com/github/github/pull/200660).

https://user-images.githubusercontent.com/2043348/144933752-2c70c3a2-9eef-4834-8391-460e25a29967.mp4



